### PR TITLE
Review have to have taget object id.

### DIFF
--- a/app/assets/alloy/sync/acs.js
+++ b/app/assets/alloy/sync/acs.js
@@ -59,6 +59,13 @@ function Sync( method, model, opts) {
             Ti.API.info(' updating object with id ' + model.id);
 
             var params = model.toJSON(), id_name = object_name.replace(/s+$/, "") + "_id";
+            params[id_name] = model.id = opts.id || model.id;
+            
+            if(model.config.settings.object_method === "Reviews"){
+				var reviewdObject = model.get('reviewed_object');
+            	params[reviewdObject.type.toLowerCase()+'_id'] = reviewdObject.id;
+            }
+            
             object_method.update(params, function(e) {
                 if (e.success) {
                     model.meta = e.meta;
@@ -81,6 +88,11 @@ function Sync( method, model, opts) {
                 params[id_name] = model.id;
             }
 
+			if(model.config.settings.object_method === "Reviews"){
+				var reviewdObject = model.get('reviewed_object');
+            	params[reviewdObject.type.toLowerCase()+'_id'] = reviewdObject.id;
+            }
+            
             object_method.remove(params, function(e) {
                 if (e.success) {
                     model.meta = e.meta;

--- a/app/assets/alloy/sync/acs.js
+++ b/app/assets/alloy/sync/acs.js
@@ -38,7 +38,7 @@ function Sync( method, model, opts) {
             var id_name = object_name.replace(/s+$/, "") + "_id", params = {};
             params[id_name] = model.id = opts.id || model.id;
 
-	    !opts.data ? opts.data = {} : opts.data;
+	        !opts.data ? opts.data = {} : opts.data;
             if (model.config.settings.object_method === "Objects") {
                 opts.data['classname'] = object_name;
                 opts.data['id'] = model.id;


### PR DESCRIPTION
This PR has two changes.

### 1. On Review's DELETE and UPDATE, adapter have to add a target's object id.
Look below appcelerator's example (post_id required):

```javascript
Cloud.Reviews.remove({
    post_id: savedPostId,
    review_id: savedReviewId
}, function (e) {
    if (e.success) {
        alert('Success');
    } else {
        alert('Error:\n' +
            ((e.error && e.message) || JSON.stringify(e)));
    }
});
```

### 2. move one line that check `!opts.data`.
line 41 : `!opts.data` should be checked before if. Because `opts.data` be used in `else`